### PR TITLE
Fix Twig template Sonata Form Type Autocomplete

### DIFF
--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -284,7 +284,6 @@ file that was distributed with this source code.
                 $(document).ajaxSuccess(function(event, xhr, settings) {
                   if(typeof xhr.responseJSON != 'undefined') {
                       if ('{{ create_url }}'.indexOf(settings.url) !== -1 && typeof xhr.responseJSON != 'string' && xhr.responseJSON.result == 'ok') {
-                        var form = JSON.parse('{"' + decodeURI(settings.data).replace('+', ' ').replace(/"/g, '\\"').replace(/&/g, '","').replace(/=/g,'":"') + '"}');
                         var item = new Option(
                           new DOMParser().parseFromString(xhr.responseJSON.objectName, "text/html").documentElement.textContent,
                           xhr.responseJSON.objectId,
@@ -298,7 +297,7 @@ file that was distributed with this source code.
                           var data = item;
                         {%- endif -%}
 
-                        $('#{{ id }}_hidden_inputs_wrap').html('<input type="hidden" name="{{ full_name }}" value="'+xhr.responseJSON.objectId+'" />');
+                        $('#{{ id }}_hidden_inputs_wrap').html('<input type="hidden" name="{{ full_name }}[]" value="'+xhr.responseJSON.objectId+'" />');
 
                         // append to Select2
                         autocompleteInput.select2('data', data).append(data).trigger('change');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Fix Twig template Sonata Form Type Autocomplete

<!-- Describe your Pull Request content here -->
Adding a new item such as an image using the autocomplete form type could result in an exception, as an array was expected via the form, but a string was returned. Also, a variable decoding a JSON string was crashing the JavaScript on the page, while it was not being used.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I want to patch the recent version of Sonata as it's currently broken.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #5426

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
Fix JavaScript exception and incorrect form input type for Autocomplete form type
```